### PR TITLE
Enable https to devServer to access navigator.usb API

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     contentBase: path.join(__dirname, 'dist'),
     compress: true,
     port: 9001,
+    https: true,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Fixes #9 

It seems like `navigator.usb` API is only available over HTTPS.