### PR TITLE
#3 Adding SPA support for GitHub Pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -5,6 +5,7 @@
     </md-app-toolbar>
     <md-app-content>
       <router-view />
+      <footer id="footer">DigiView Web - <router-link to="/about">About</router-link></footer>
     </md-app-content>
   </md-app>
 </template>
@@ -32,5 +33,12 @@ export default {
   }
   .md-app-toolbar .md-title {
     color: white!important;
+  }
+  #footer {
+    position: absolute;
+    text-align: center;
+    bottom: 1em;
+    left: 0;
+    right: 0;
   }
 </style>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -7,6 +7,30 @@
   <title>DigiView - Web</title>
   <meta name="description" content="View your digital FPV in your browser!">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Start Single Page Apps for GitHub Pages -->
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // MIT License
+    // https://github.com/rafgraph/spa-github-pages
+    // This script checks to see if a redirect is present in the query string,
+    // converts it back into the correct url and adds it to the
+    // browser's history using window.history.replaceState(...),
+    // which won't cause the browser to attempt to load the new url.
+    // When the single page app is loaded further down in this file,
+    // the correct url will be waiting in the browser's history for
+    // the single page app to route accordingly.
+    (function(l) {
+      if (l.search[1] === '/' ) {
+        var decoded = l.search.slice(1).split('&').map(function(s) { 
+          return s.replace(/~and~/g, '&')
+        }).join('?');
+        window.history.replaceState(null, null,
+            l.pathname.slice(0, -1) + decoded + l.hash
+        );
+      }
+    }(window.location))
+  </script>
+  <!-- End Single Page Apps for GitHub Pages -->
 </head>
 
 <body>

--- a/src/ui/router/routes.ts
+++ b/src/ui/router/routes.ts
@@ -4,4 +4,9 @@ export default [
     name: 'view-usb',
     component: () => import('~/ui/views/ViewUSB/Index.vue'),
   },
+  {
+    path: '/about',
+    name: 'about',
+    component: () => import('~/ui/views/About/Index.vue'),
+  },
 ];

--- a/src/ui/views/About/Index.vue
+++ b/src/ui/views/About/Index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    For more info visit: <a href="https://fpvout.com/">fpvout.com</a>
+  </div>
+</template>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,14 @@ module.exports = {
     compress: true,
     port: 9001,
     https: true,
+    // We need this rewrite rule to test 404 page in development, copy 404.html file
+    // to the dist folder manually, it's git-ignored anyways, once we're confident
+    // this is working, we can change the directive historyApiFallback to true.
+    historyApiFallback: {
+      rewrites: [
+        { from: /^\/.+/, to: '/404.html' },
+      ],
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
* Adding 404.html file and redirection scripts as described in: https://github.com/rafgraph/spa-github-pages
* Updated Webpack's config to enable History API Fallback (with a workaround for development environment, see comments)
* Added the footer with a `router-link` to the new About page.
* The About page is intended to test the redirections and the SPA behavior, we may remove it if needed.